### PR TITLE
Added missing manifest and titanium.xcconfig files

### DIFF
--- a/iphone/manifest
+++ b/iphone/manifest
@@ -1,0 +1,18 @@
+#
+# this is your module manifest and used by Titanium
+# during compilation, packaging, distribution, etc.
+#
+version: 2.0.0
+apiversion: 2
+architectures: armv7 arm64 i386 x86_64
+description: Listen for native screenshots
+author: Marcel Pociot
+license: MIT
+copyright: Copyright (c) 2013-2014 by Marcel Pociot
+
+# these should not be edited
+name: TiScreenshotDetection
+moduleid: de.marcelpociot.screenshot
+guid: 544290ca-7002-4cf4-8b20-feedb53f1000
+platform: iphone
+minsdk: 9.2.0

--- a/iphone/titanium.xcconfig
+++ b/iphone/titanium.xcconfig
@@ -1,0 +1,15 @@
+//
+//
+// CHANGE THESE VALUES TO REFLECT THE VERSION (AND LOCATION IF DIFFERENT)
+// OF YOUR TITANIUM SDK YOU'RE BUILDING FOR
+//
+//
+TITANIUM_SDK_VERSION = 9.3.2.GA
+
+
+//
+// THESE SHOULD BE OK GENERALLY AS-IS
+//
+TITANIUM_SDK = /Users/$(USER)/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
+HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"


### PR DESCRIPTION
Both files have been created/updated to use TiSDK 9.2.0+ for ARM64 (Apple Silicon) support.